### PR TITLE
process the last clock items correctly

### DIFF
--- a/org2tc
+++ b/org2tc
@@ -27,6 +27,18 @@ acct         = "<None>"
 
 (billcode, taskcode) = ("<Unknown>", None)
 
+def add_events():
+    # XXX: those globals should really be cleaned up, maybe through a clock object or named tuple
+    global acct, clocks, billcode, taskcode, events, todo_keyword, last_heading
+    if clocks:
+        for (clock_in, clock_out, billcode, taskcode) in clocks:
+            if billcode and ":" not in billcode and taskcode:
+                acct = "%s:%s" % (billcode, taskcode)
+            events.append((clock_in, clock_out, todo_keyword,
+                           ("%s  %s" % (acct, last_heading))
+                           if acct else last_heading))
+        clocks = []
+
 for line in fd:
     match = re.search("^(\*+)\s*(.+)", line)
     if match:
@@ -36,14 +48,7 @@ for line in fd:
     depth = 0
     match = re.search("^(\*+)\s+([A-Z]{4}[A-Z]*)?(\s+\[#[ABC]\])?\s*(.+)", line)
     if match:
-        if clocks:
-            for (clock_in, clock_out, billcode, taskcode) in clocks:
-                if billcode and ":" not in billcode and taskcode:
-                    acct = "%s:%s" % (billcode, taskcode)
-                events.append((clock_in, clock_out, todo_keyword,
-                               ("%s  %s" % (acct, last_heading))
-                               if acct else last_heading))
-            clocks = []
+        add_events()
 
         depth = len(match.group(1))
         todo_keyword = match.group(2)
@@ -101,6 +106,7 @@ for line in fd:
             taskcode = match.group(1)
 
 fd.close()
+add_events()
 
 def event_compare(x, y):
     xt = time.mktime(x[0])


### PR DESCRIPTION
without this, the clock under the last heading of the org file wouldn't be added like the other events

it's a little ugly of a fix because we need to access all those globals, but it beats copy-pasting the code.

Closes: https://github.com/jwiegley/org2tc/issues/2
