### PR TITLE
Add an argument for setting the default billcode

### DIFF
--- a/org2tc
+++ b/org2tc
@@ -81,7 +81,7 @@ parser.add_argument('-r', '--regex', help='process only entries matching this re
 parser.add_argument('-o', '--output', help='output file (default: stdout)',
                     type=argparse.FileType('w'), default=sys.stdout)
 parser.add_argument('-b', '--billcode', help='default billcode if not found (default: <Unknown>',
-                    default='<Unknown>')
+                    default=None)
 
 args = parser.parse_args()
 
@@ -92,10 +92,20 @@ regex       = args.regex
 for fd in args.orgfiles:
     headings = [None] * 9
     acct     = "<None>"
+    contents = fd.read()
 
-    (billcode, taskcode) = (args.billcode, None)
+    (billcode, taskcode) = (None, None)
 
-    for line in fd:
+    if args.billcode is None:
+        match = re.search('\n#\+PROPERTY: BILLCODE (.+)\n', contents, re.IGNORECASE)
+        if match:
+            billcode = match.group(1)
+        else:
+            billcode = '<Unknown>'
+    else:
+        billcode = args.billcode
+
+    for line in contents.splitlines():
         match = re.search("^(\*+)\s*(.+)", line)
         if match:
             headings[len(match.group(1))] = match.group(2)

--- a/org2tc
+++ b/org2tc
@@ -80,6 +80,8 @@ parser.add_argument('-e', '--end', metavar='TIME', help='process only entries to
 parser.add_argument('-r', '--regex', help='process only entries matching this regex')
 parser.add_argument('-o', '--output', help='output file (default: stdout)',
                     type=argparse.FileType('w'), default=sys.stdout)
+parser.add_argument('-b', '--billcode', help='default billcode if not found (default: <Unknown>',
+                    default='<Unknown>')
 
 args = parser.parse_args()
 
@@ -91,7 +93,7 @@ for fd in args.orgfiles:
     headings = [None] * 9
     acct     = "<None>"
 
-    (billcode, taskcode) = ("<Unknown>", None)
+    (billcode, taskcode) = (args.billcode, None)
 
     for line in fd:
         match = re.search("^(\*+)\s*(.+)", line)


### PR DESCRIPTION
This is useful when you have a single billcode set for the entire org file. For
example, the org file has a '#+PROPERTY: BILLCODE X' at the top. The rest of the
python code will not detect this billcode, but you could set it manually at the
command line.